### PR TITLE
Package.json: Switch to cssnano

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ elixir.extend('postcss', function(src, options) {
     return gulp.src(options.srcDir + src)
       .pipe(plugins.if(config.sourcemaps, plugins.sourcemaps.init()))
       .pipe(plugins.postcss(options.plugins).on('error', err))
-      .pipe(plugins.if(config.production, plugins.minifyCss()))
+      .pipe(plugins.if(config.production, plugins.cssnano(config.css.cssnano.pluginOptions)))
       .pipe(plugins.if(config.sourcemaps, plugins.sourcemaps.write('.')))
       .pipe(gulp.dest(options.output))
       .pipe(new notification().message(name + ' Compiled!'));

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "underscore": "^1.8.2",
     "gulp-postcss": "^6.0.1",
     "gulp-if": "^1.2.5",
-    "gulp-minify-css": "^0.3.10",
+    "gulp-cssnano": "^2.0.0",
     "gulp-load-plugins": "^0.7.0",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-util": "^3.0.6"


### PR DESCRIPTION
https://www.npmjs.com/package/gulp-minify-css

Gulp-minify-css has been deprecated, so let's use cssnano instead (with plugin options).
