### PR TITLE
Bump gulp-load-plugins version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-postcss": "^6.0.1",
     "gulp-if": "^1.2.5",
     "gulp-cssnano": "^2.0.0",
-    "gulp-load-plugins": "^0.7.0",
+    "gulp-load-plugins": "^1.2.0",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-util": "^3.0.6"
   },


### PR DESCRIPTION
Just to get rid of deprecation message:

`npm WARN deprecated lodash@2.4.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0`

So far I haven't noticed any problems with this version.
