### PR TITLE
Add extra 'watch' directories support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Or run `gulp watch`
   plugins : [],
   srcDir  : 'resources/assets/postcss/',
   sourcemaps: true, // default value follow `elixir.config.sourcemaps`
+  watch: [], // set additional watch directories here.
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ elixir.extend('postcss', function(src, options) {
     plugins: [],
     srcDir: 'resources/assets/postcss/',
     sourcemaps: options.sourcemaps ? options.sourcemaps : config.sourcemaps,
+    watch: [],
   }, options);
 
   new elixir.Task(name, function() {
@@ -51,6 +52,6 @@ elixir.extend('postcss', function(src, options) {
       .pipe(gulp.dest(options.output))
       .pipe(new notification().message(name + ' Compiled!'));
   })
-  .watch([options.srcDir + '/**/*.css']);
+  .watch(_.union([options.srcDir + '/**/*.css'], options.watch));
 
 });


### PR DESCRIPTION
I needed to watch some directories other than resources/assets/postcss, so added this - useful to others maybe?
